### PR TITLE
original code has problems: dies if no running jobs at the moment (gn…

### DIFF
--- a/gnt-running.sh
+++ b/gnt-running.sh
@@ -1,4 +1,10 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 while true ; do
-gnt-job list --no-headers --running | tee /dev/stderr | awk '{ print $1 }' | xargs gnt-job watch
+  JOBID=`gnt-job list --no-headers --running | tee /dev/stderr | awk '{ print $1; exit }'`
+  if [ -n "$JOBID" ]
+  then
+	gnt-job watch $JOBID
+  else
+	sleep 5
+  fi
 done


### PR DESCRIPTION
original code has problems: 

- dies if no running jobs at the moment ("gnt-job watch" without args throws error due to "-e")
- dies if more than one job running ("gnt-job watch" with multiple args throws error due to "-e")
- hammers the server if no jobs are running (no sleep between "gnt-job list" commands)

this fixes all 3.